### PR TITLE
upm-ci: pack on OSX to avoid \ (FTV-19)

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -15,9 +15,9 @@ test_platforms:
 pack:
   name: Pack
   agent:
-    type: Unity::VM
-    image: package-ci/win10:stable
-    flavor: m1.large
+    type: Unity::VM::osx
+    image: buildfarm/mac:stable
+    flavor: m1.mac
   commands:
     - npm install upm-ci-utils -g --registry https://api.bintray.com/npm/unity/unity-npm
     - upm-ci package pack --package-path com.unity.film-tv.toolbox

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -19,7 +19,7 @@ pack:
     image: buildfarm/mac:stable
     flavor: m1.mac
   commands:
-    - npm install upm-ci-utils -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
     - upm-ci package pack --package-path com.unity.film-tv.toolbox
   artifacts:
     packages:
@@ -35,7 +35,7 @@ test_{{ platform.name }}_{{ editor.version }}:
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
   commands:
-    - npm install upm-ci-utils -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
     - upm-ci package test --unity-version {{ editor.version }} --package-path com.unity.film-tv.toolbox
   artifacts:
     logs.zip:
@@ -80,7 +80,7 @@ publish:
     image: package-ci/win10:stable
     flavor: m1.large
   commands:
-    - npm install upm-ci-utils -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
     - upm-ci package publish --package-path com.unity.film-tv.toolbox
   triggers:
     tags:

--- a/com.unity.film-tv.toolbox/CHANGELOG.md
+++ b/com.unity.film-tv.toolbox/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.1.0-preview.0] - 2019-04-15
+## [0.1.0-preview.1] - 2019-04-11
 * Initialisation of the package
 * Material Remapper
+* Shotgun CSV Import / Export sample

--- a/com.unity.film-tv.toolbox/package.json
+++ b/com.unity.film-tv.toolbox/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.unity.film-tv.toolbox",
 	"displayName":"Film and TV Toolbox",
-	"version": "0.1.0-preview.0",
+	"version": "0.1.0-preview.1",
 	"unity": "2018.3",
 	"description": "This package is a collection of experimental, proof of concept or helper tools for Film / TV productions.",
 	"keywords": ["film", "TV", "Tools", "Samples"],


### PR DESCRIPTION
Resolution  of samples currently introduced \.
Bug has been reported already, in the meantime, we can pack on OSX.