### PR TITLE
Material remapper fix

### DIFF
--- a/com.unity.film-tv.toolbox/Editor/MaterialRemapper/MaterialRemapperModel.cs
+++ b/com.unity.film-tv.toolbox/Editor/MaterialRemapper/MaterialRemapperModel.cs
@@ -132,7 +132,7 @@ namespace UnityEditor.FilmTV.Toolbox
 
                 if( matList.Count > 0)
                 {
-                    Undo.RegisterCompleteObjectUndo(sourceMesh.sharedMaterials.Cast<UnityEngine.Object>().ToArray(), "Assign Materials");
+                    Undo.RegisterCompleteObjectUndo(sourceMesh.sharedMaterials.Cast<UnityEngine.Object>().Where(x=>x != null).ToArray(), "Assign Materials");
                     Debug.Log("Applying materials...");
                     sourceMesh.sharedMaterials = matList.ToArray();
                 }

--- a/com.unity.film-tv.toolbox/Editor/MaterialRemapper/MaterialRemapperModel.cs
+++ b/com.unity.film-tv.toolbox/Editor/MaterialRemapper/MaterialRemapperModel.cs
@@ -132,7 +132,7 @@ namespace UnityEditor.FilmTV.Toolbox
 
                 if( matList.Count > 0)
                 {
-                    Undo.RegisterCompleteObjectUndo(sourceMesh.sharedMaterials.Cast<UnityEngine.Object>().Where(x=>x != null).ToArray(), "Assign Materials");
+                    Undo.RegisterCompleteObjectUndo(sourceMesh, "Assign Materials");
                     Debug.Log("Applying materials...");
                     sourceMesh.sharedMaterials = matList.ToArray();
                 }

--- a/com.unity.film-tv.toolbox/Editor/MaterialRemapper/MaterialRemapperView.cs
+++ b/com.unity.film-tv.toolbox/Editor/MaterialRemapper/MaterialRemapperView.cs
@@ -150,10 +150,11 @@ namespace UnityEditor.FilmTV.Toolbox
                                     var materialName = model.materialList[i] != null
                                         ? model.materialList[i].name
                                         : "None";
-                                    model.materialList[i] = (Material) EditorGUILayout.ObjectField(materialName,
-                                        model.materialList[i], typeof(Material), true, GUILayout.MinWidth(400));
+                                    
+                                    model.materialList[i] = EditorGUILayout.ObjectField(materialName,
+                                        model.materialList[i], typeof(Material), true, GUILayout.MinWidth(400)) as Material;
                                 }
-                                
+
                             }
                             EditorGUILayout.EndVertical();
                         }

--- a/com.unity.film-tv.toolbox/Editor/MaterialRemapper/MaterialRemapperView.cs
+++ b/com.unity.film-tv.toolbox/Editor/MaterialRemapper/MaterialRemapperView.cs
@@ -189,8 +189,10 @@ namespace UnityEditor.FilmTV.Toolbox
                                             // show all of the materials in the mesh
                                             for (var j = 0; j < remapItem.mesh.sharedMaterials.Length; j++)
                                             {
+                                                var options = model.materialList
+                                                    .Select(x => x != null ? x.name.Replace('#',' ') : "None").ToArray();
                                                 // do we have any materials to remap
-                                                remapItem.selectedIndex[j] = EditorGUILayout.Popup(remapItem.selectedIndex[j], model.materialList.Select(x=>x !=null ? x.name : "None").ToArray(), GUILayout.Width(200));
+                                                remapItem.selectedIndex[j] = EditorGUILayout.Popup(remapItem.selectedIndex[j], options, GUILayout.Width(200));
                                             }
 
                                             EditorGUILayout.EndHorizontal();

--- a/com.unity.film-tv.toolbox/Editor/MaterialRemapper/MaterialRemapperView.cs
+++ b/com.unity.film-tv.toolbox/Editor/MaterialRemapper/MaterialRemapperView.cs
@@ -148,7 +148,10 @@ namespace UnityEditor.FilmTV.Toolbox
 
                                 for (var i = 0; i < model.materialList.Count; i++)
                                 {
-                                    model.materialList[i] = (Material) EditorGUILayout.ObjectField(model.materialList[i].name,
+                                    var materialName = model.materialList[i] != null
+                                        ? model.materialList[i].name
+                                        : "None";
+                                    model.materialList[i] = (Material) EditorGUILayout.ObjectField(materialName,
                                         model.materialList[i], typeof(Material), true, GUILayout.MinWidth(400));
                                 }
                                 
@@ -187,7 +190,7 @@ namespace UnityEditor.FilmTV.Toolbox
                                             for (var j = 0; j < remapItem.mesh.sharedMaterials.Length; j++)
                                             {
                                                 // do we have any materials to remap
-                                                remapItem.selectedIndex[j] = EditorGUILayout.Popup(remapItem.selectedIndex[j], model.materialList.Select(x=>x.name).ToArray(), GUILayout.Width(200));
+                                                remapItem.selectedIndex[j] = EditorGUILayout.Popup(remapItem.selectedIndex[j], model.materialList.Select(x=>x !=null ? x.name : "None").ToArray(), GUILayout.Width(200));
                                             }
 
                                             EditorGUILayout.EndHorizontal();

--- a/com.unity.film-tv.toolbox/Editor/MaterialRemapper/MaterialRemapperView.cs
+++ b/com.unity.film-tv.toolbox/Editor/MaterialRemapper/MaterialRemapperView.cs
@@ -140,7 +140,6 @@ namespace UnityEditor.FilmTV.Toolbox
                                         var newMat = MaterialRemapperModel.GetDefaultMaterial();
                                         // add to our temp list of materials
                                         model.materialList.Add(newMat);
-                                        newMat.name = "MaterialRemap";
                                     }
                                     
                                 }


### PR DESCRIPTION
This branch has 2 fixes:
- Fix for null materials entries in MeshRenderers (missing material references for ex)
- Fix for undo (the main problem was the MeshRenderers were not marked dirty so there is no visual indication that you need to save your project - your changes are lost unless you save ). Bug left: window does not refresh when Undo-ing
